### PR TITLE
Update azkaban admin user rotation pipeline to duplicate password in all envs

### DIFF
--- a/ci/jobs/rotate_azkaban_admin.yml
+++ b/ci/jobs/rotate_azkaban_admin.yml
@@ -6,38 +6,58 @@ jobs:
         params:
           TF_WORKSPACE: management-dev
           AWS_SECRETS_ROLE: arn:aws:iam::((aws_account.management-dev)):role/ci
+      - .: (( inject meta.plan.generate-random-password ))
+        params:
+          AWS_ACC: ((aws_account.management-dev))
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
       - .: (( inject meta.plan.terraform-output-dataworks-cognito ))
-      - .: (( inject meta.plan.rotate-azkaban-admin-cognito-user ))
-        config:
+      - .: (( inject meta.plan.update-cognito-user-password ))
+        params:
+          AWS_ACC: ((aws_account.management-dev))
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
+      - in_parallel:
+        - .: (( inject meta.plan.update-secretsmanager-secret-password ))
           params:
-            AWS_ACC: ((aws_account.management-dev))
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
-            AWS_REGION: "eu-west-2"
+            AWS_ACC: ((aws_account.development))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
             SECRET_ID: "/concourse/dataworks/workflow_manager/azkaban_external/cognito"
-          inputs:
-            - name: terraform-output
+        - .: (( inject meta.plan.update-secretsmanager-secret-password ))
+          params:
+            AWS_ACC: ((aws_account.qa))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
+            SECRET_ID: "/concourse/dataworks/workflow_manager/azkaban_external/cognito"
+        - .: (( inject meta.plan.update-secretsmanager-secret-password ))
+          params:
+            AWS_ACC: ((aws_account.integration))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
+            SECRET_ID: "/concourse/dataworks/workflow_manager/azkaban_external/cognito"
+
 
   - name: azkaban-admin-cognito-management
     plan:
       - get: dataworks-cognito
       - .: (( inject meta.plan.terraform-bootstrap-dataworks-cognito ))
         params:
-          TF_WORKSPACE: management
+          TF_WORKSPACE: management-dev
           AWS_SECRETS_ROLE: arn:aws:iam::((aws_account.management)):role/ci
+      - .: (( inject meta.plan.generate-random-password ))
+        params:
+          AWS_ACC: ((aws_account.management))
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
       - .: (( inject meta.plan.terraform-output-dataworks-cognito ))
-        config:
-          params:
-            TF_WORKSPACE: management
-            AWS_ACC: ((aws_account.management))
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
-            AWS_REGION: "eu-west-2"
-      - .: (( inject meta.plan.rotate-azkaban-admin-cognito-user ))
-        config:
-          params:
-            AWS_ACC: ((aws_account.management))
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
-            AWS_REGION: "eu-west-2"
-            SECRET_ID: "/concourse/dataworks/workflow_manager/azkaban_external/cognito"
-          inputs:
-            - name: terraform-output
+      - .: (( inject meta.plan.update-cognito-user-password ))
+        params:
+          AWS_ACC: ((aws_account.management))
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+      - in_parallel:
+          - .: (( inject meta.plan.update-secretsmanager-secret-password ))
+            params:
+              AWS_ACC: ((aws_account.preprod))
+              AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
+              SECRET_ID: "/concourse/dataworks/workflow_manager/azkaban_external/cognito"
+          - .: (( inject meta.plan.update-secretsmanager-secret-password ))
+            params:
+              AWS_ACC: ((aws_account.production))
+              AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
+              SECRET_ID: "/concourse/dataworks/workflow_manager/azkaban_external/cognito"
 

--- a/ci/jobs/rotate_azkaban_admin.yml
+++ b/ci/jobs/rotate_azkaban_admin.yml
@@ -11,6 +11,9 @@ jobs:
           AWS_ACC: ((aws_account.management-dev))
           AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
       - .: (( inject meta.plan.terraform-output-dataworks-cognito ))
+        params:
+          TF_WORKSPACE: management-dev
+          AWS_SECRETS_ROLE: arn:aws:iam::((aws_account.management-dev)):role/ci
       - .: (( inject meta.plan.update-cognito-user-password ))
         params:
           AWS_ACC: ((aws_account.management-dev))
@@ -38,13 +41,16 @@ jobs:
       - get: dataworks-cognito
       - .: (( inject meta.plan.terraform-bootstrap-dataworks-cognito ))
         params:
-          TF_WORKSPACE: management-dev
+          TF_WORKSPACE: management
           AWS_SECRETS_ROLE: arn:aws:iam::((aws_account.management)):role/ci
       - .: (( inject meta.plan.generate-random-password ))
         params:
           AWS_ACC: ((aws_account.management))
           AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
       - .: (( inject meta.plan.terraform-output-dataworks-cognito ))
+        params:
+          TF_WORKSPACE: management
+          AWS_SECRETS_ROLE: arn:aws:iam::((aws_account.management)):role/ci
       - .: (( inject meta.plan.update-cognito-user-password ))
         params:
           AWS_ACC: ((aws_account.management))

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -451,8 +451,8 @@ meta:
         outputs:
           - name: terraform-success
 
-    rotate-azkaban-admin-cognito-user:
-      task: rotate-azkaban-admin-cognito-user
+    generate-random-password:
+      task: generate-random-password
       config:
         platform: linux
         image_resource:
@@ -463,19 +463,62 @@ meta:
         params:
           AWS_REGION: ((dataworks.aws_region))
           AWS_DEFAULT_REGION: ((dataworks.aws_region))
-          SECRET_ID: ((SECRET_ID))
         run:
           path: sh
           args:
             - -exc
             - |
               source /assume-role
-              RANDOM_PASSWORD=$(aws secretsmanager get-random-password --password-length 25 --no-include-space --require-each-included-type | jq -r .RandomPassword)
-              UPDATED_SECRET_BINARY=$(aws secretsmanager get-secret-value --secret-id $SECRET_ID --query SecretBinary --output text | base64 -d | jq -r --arg data "$RANDOM_PASSWORD" '.azkaban_password = $data')
-              aws secretsmanager put-secret-value --secret-id $SECRET_ID --secret-binary "${UPDATED_SECRET_BINARY}"
+              aws secretsmanager get-random-password --password-length 25 --no-include-space --require-each-included-type | jq -r .RandomPassword >> random-password/random-password.txt
+        outputs:
+          - name: random-password
 
+
+    update-cognito-user-password:
+      task: update-cognito-user-password
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.docker_awscli_repository))
+            tag: ((dataworks.docker_awscli_version))
+        params:
+          AWS_REGION: ((dataworks.aws_region))
+          AWS_DEFAULT_REGION: ((dataworks.aws_region))
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              source /assume-role
+              RANDOM_PASSWORD=$(cat random-password/random-password.txt)
               USER_POOL_ID=$(jq -r '.cognito.value.user_pool.id' terraform-output/outputs.json)
               aws cognito-idp admin-set-user-password --user-pool-id $USER_POOL_ID --username azkaban_admin --password $RANDOM_PASSWORD --permanent --region $AWS_REGION
-
         inputs:
           - name: terraform-output
+          - name: random-password
+
+    update-secretsmanager-secret-password:
+      task: update-secretsmanager-secret-password
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.docker_awscli_repository))
+            tag: ((dataworks.docker_awscli_version))
+        params:
+          AWS_REGION: ((dataworks.aws_region))
+          AWS_DEFAULT_REGION: ((dataworks.aws_region))
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              source /assume-role
+              RANDOM_PASSWORD=$(cat random-password/random-password.txt)
+              UPDATED_SECRET_BINARY=$(aws secretsmanager get-secret-value --secret-id $SECRET_ID --query SecretBinary --output text | base64 -d | jq -r --arg data "$RANDOM_PASSWORD" '.azkaban_password = $data')
+              aws secretsmanager put-secret-value --secret-id $SECRET_ID --secret-binary "${UPDATED_SECRET_BINARY}"
+        inputs:
+          - name: random-password


### PR DESCRIPTION
So that the mgmt-dev and management respective accounts have the value without having to assume role to management envs for it.
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>