### PR TITLE
copy security config

### DIFF
--- a/config/azkaban/exec-server/commonprivate.properties
+++ b/config/azkaban/exec-server/commonprivate.properties
@@ -3,5 +3,6 @@ azkaban.native.lib=/azkaban-exec-server
 aws.emr.cluster.name=user-batch-analytical-env
 aws.emr.step.name=batch-step
 aws.emr.step.script=/home/hadoop/step.sh
+aws.emr.copy.secconfig=true
 aws.region=eu-west-2
 use.emr.user=true


### PR DESCRIPTION
copy security config so that the taint and apply job can make changes to the original security config where needed while the batch cluster is running