### PR TITLE
double Fargate CPU

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "whitelist_cidr_blocks" {
 }
 
 variable "fargate_cpu" {
-  default = "256"
+  default = "512"
 }
 
 variable "fargate_memory" {


### PR DESCRIPTION
Doubles the CPU units for the Fargate tasks. Hopefully to resolve CPU spiking and user log outs.