### PR TITLE
Add health check grace period - Prevent instant destruction of container

### DIFF
--- a/azkaban_executor_ecs.tf
+++ b/azkaban_executor_ecs.tf
@@ -68,6 +68,7 @@ resource "aws_ecs_service" "azkaban_executor" {
   launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 60
 
   network_configuration {
     security_groups = [aws_security_group.azkaban_executor.id, aws_security_group.workflow_manager_common.id]

--- a/azkaban_external_executor_ecs.tf
+++ b/azkaban_external_executor_ecs.tf
@@ -65,6 +65,7 @@ resource "aws_ecs_service" "azkaban_external_executor" {
   launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 60
 
   network_configuration {
     security_groups = [aws_security_group.azkaban_external_executor.id, aws_security_group.workflow_manager_common.id]

--- a/azkaban_webserver_ecs.tf
+++ b/azkaban_webserver_ecs.tf
@@ -78,6 +78,7 @@ resource "aws_ecs_service" "azkaban_webserver" {
   launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 60
 
   network_configuration {
     security_groups = [aws_security_group.azkaban_webserver.id, aws_security_group.workflow_manager_common.id]


### PR DESCRIPTION
Azkaban containers are Java apps and take a moment to come up properly - Prevent AWS killing a container prematurely.

Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>